### PR TITLE
Fix reference to email test command

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Once you have verified your sending domain, you are all good to go!
 Other Commands
 =======
 
-`wp aws-ses send-email <to> <subject> <message> [---from-email=<email>]`
+`wp aws-ses send <to> <subject> <message> [---from-email=<email>]`
 
 Send a test email via the command line. Good for testing!
 


### PR DESCRIPTION
`Error: 'send-email' is not a registered subcommand of 'aws-ses'. See 'wp help aws-ses'` currently is what is output.
